### PR TITLE
fix: rename master to main in cicd workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CI-CD
 
 on:
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
     types:
       - edited
       - labeled
@@ -10,7 +10,7 @@ on:
       - reopened
       - synchronize
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
     paths:
       - '../labels.yml'
   workflow_dispatch:


### PR DESCRIPTION
## Description

Correct `cicd` workflow branch name.

## Related Issue

Close #10 

## Checklist
- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add unique feature``)
