### PR TITLE
feat: add RC opening move

### DIFF
--- a/lib/common/config.h
+++ b/lib/common/config.h
@@ -21,7 +21,7 @@ extern "C" {
  * - `RADIO`:       radio receiver will decide on how to operate
  */
 typedef enum {
-    AUTONOMOUS,
+    AUTONOMOUS = 0,
     RADIO,
 } control_mode_t;
 

--- a/lib/common/config.h
+++ b/lib/common/config.h
@@ -38,6 +38,11 @@ typedef enum {
  */
 #define SYSTEM_DEBUG_LEVEL  DEBUG_LEVEL_WARNING
 
+/**
+ * 
+ */
+#define OPENING_ITERATIONS  3
+
 
 
 

--- a/lib/common/config.h
+++ b/lib/common/config.h
@@ -34,7 +34,8 @@ typedef enum {
 /**
  * @brief System-wide Debug Threshold
  * 
- * Defines which debug messages will be displayed.
+ * Defines which debug messages will be displayed with DEBUG_LEVEL_WARNING by
+ * default.
  */
 #define SYSTEM_DEBUG_LEVEL  DEBUG_LEVEL_WARNING
 

--- a/lib/debug/debug.cpp
+++ b/lib/debug/debug.cpp
@@ -20,7 +20,6 @@ static const char *file_basename(const char *path) {
 
 void debug_init(uint32_t baud_rate) {
     Serial.begin(baud_rate);
-    delay(10);
 }
 
 

--- a/lib/debug/debug.h
+++ b/lib/debug/debug.h
@@ -26,7 +26,7 @@ extern "C" {
  * @brief Defines debug logging levels.
  * 
  * Available levels are:
- * 
+ *
  * - `DEBUG_LEVEL_CRITICAL`:    System Failure
  *
  * - `DEBUG_LEVEL_ERROR`:       Recoverable Error
@@ -128,7 +128,7 @@ void debug_message(int level, const char *file, const char *func, int line, cons
  *
  * - `__LINE__`
  *
- * @param level `debug_level_t` bebug severity level.
+ * @param level `debug_level_t` debug severity level.
  * @param fmt   `string` printf-style message.
  * @param ...   Additional arguments corresponding to the format string.
  */

--- a/lib/drivers/esc/esc.cpp
+++ b/lib/drivers/esc/esc.cpp
@@ -79,7 +79,10 @@ void esc_set_pwm_neutral(motor_t motor) {
 
 void esc_set_pwms(pwm_pulse_norm_t pulses_us[NUMBER_OF_MOTORS]) {
     pwm_pulse_norm_t throttle_us = pulses_us[0];
+    DEBUG_MSG(DEBUG_LEVEL_TRACE, "measured steering: %d us", pulses_us[0]);
+
     pwm_pulse_norm_t steering_us = pulses_us[1];
+    DEBUG_MSG(DEBUG_LEVEL_TRACE, "measured throttle: %d us", pulses_us[1]);
 
     esc_set_pwm((pwm_pulse_t) throttle_us + steering_us - PWM_NEUTRAL_US, MOTOR_L);
     esc_set_pwm((pwm_pulse_t) throttle_us - steering_us + PWM_NEUTRAL_US, MOTOR_R);

--- a/lib/drivers/esc/esc.cpp
+++ b/lib/drivers/esc/esc.cpp
@@ -72,6 +72,11 @@ void esc_set_pwm(pwm_pulse_t pulse_us, motor_t motor) {
 };
 
 
+void esc_set_pwm_neutral(motor_t motor) {
+    esc_set_pwm((pwm_pulse_t) PWM_NEUTRAL_US, motor);
+}
+
+
 void esc_set_pwms(pwm_pulse_norm_t pulses_us[NUMBER_OF_MOTORS]) {
     pwm_pulse_norm_t throttle_us = pulses_us[0];
     pwm_pulse_norm_t steering_us = pulses_us[1];
@@ -80,6 +85,11 @@ void esc_set_pwms(pwm_pulse_norm_t pulses_us[NUMBER_OF_MOTORS]) {
     esc_set_pwm((pwm_pulse_t) throttle_us - steering_us + PWM_NEUTRAL_US, MOTOR_R);
 };
 
+
+void esc_set_pwms_neutral() {
+    esc_set_pwm_neutral(MOTOR_L);
+    esc_set_pwm_neutral(MOTOR_R);
+};
 
 void esc_validate() {
 

--- a/lib/drivers/esc/esc.cpp
+++ b/lib/drivers/esc/esc.cpp
@@ -50,11 +50,8 @@ void esc_init() {
         );
     }
 
-    delay(500); // initialization stabilization
-
     DEBUG_MSG(DEBUG_LEVEL_INFO, "initialization of ESC finish");
 };
-
 
 void esc_set_pwm(pwm_pulse_t pulse_us, motor_t motor) {
     pwm_pulse_norm_t pulse_norm_us = pwm_pulse_us_normalize(pulse_us);

--- a/lib/drivers/esc/esc.cpp
+++ b/lib/drivers/esc/esc.cpp
@@ -2,6 +2,7 @@
 #include "debug.h"
 #include <driver/mcpwm.h>
 #include "esc.h"
+#include "motor/motor.h"
 #include "pinout.h"
 #include "pwm/pwm.h"
 #include "radio/radio.h"
@@ -66,29 +67,6 @@ void esc_set_pwm(pwm_pulse_t pulse_us, motor_t motor) {
         MOTOR_OPERATOR(motor),
         pulse_norm_us
     );
-};
-
-
-void esc_set_pwm_neutral(motor_t motor) {
-    esc_set_pwm((pwm_pulse_t) PWM_NEUTRAL_US, motor);
-}
-
-
-void esc_set_pwms(pwm_pulse_norm_t pulses_us[NUMBER_OF_MOTORS]) {
-    pwm_pulse_norm_t throttle_us = pulses_us[0];
-    DEBUG_MSG(DEBUG_LEVEL_TRACE, "measured steering: %d us", pulses_us[0]);
-
-    pwm_pulse_norm_t steering_us = pulses_us[1];
-    DEBUG_MSG(DEBUG_LEVEL_TRACE, "measured throttle: %d us", pulses_us[1]);
-
-    esc_set_pwm((pwm_pulse_t) throttle_us + steering_us - PWM_NEUTRAL_US, MOTOR_L);
-    esc_set_pwm((pwm_pulse_t) throttle_us - steering_us + PWM_NEUTRAL_US, MOTOR_R);
-};
-
-
-void esc_set_pwms_neutral() {
-    esc_set_pwm_neutral(MOTOR_L);
-    esc_set_pwm_neutral(MOTOR_R);
 };
 
 void esc_validate() {

--- a/lib/drivers/esc/esc.h
+++ b/lib/drivers/esc/esc.h
@@ -101,13 +101,21 @@ void esc_init(void);
 void esc_set_pwm(pwm_pulse_t pulse_us, motor_t motor);
 
 /**
+ * @brief Stop both motors by commanding neutral PWM.
+ *
+ * Sets left and right ESC outputs to `PWM_NEUTRAL_US`, ensuring zero throttle
+ * condition.
+ */
+void esc_set_pwm_neutral(motor_t motor);
+
+/**
  * @brief Apply differential drive mixing and update both motors.
  *
  * Implements skid-steering (tank drive) mixing:
  *
- * - `left ` = throttle + steering
+ * - `left  = throttle + steering - PWM_NEUTRAL_US`
  *
- * - `right` = throttle - steering
+ * - `right = throttle - steering + PWM_NEUTRAL_US`
  *
  * @param pulses_us Input array:
  *
@@ -116,6 +124,9 @@ void esc_set_pwm(pwm_pulse_t pulse_us, motor_t motor);
  *        - pulses_us[1]: Steering in microseconds
  */
 void esc_set_pwms(pwm_pulse_norm_t pulses_us[NUMBER_OF_MOTORS]);
+
+// TODO add docs
+void esc_set_pwms_neutral();
 
 
 void esc_validate(void);

--- a/lib/drivers/esc/esc.h
+++ b/lib/drivers/esc/esc.h
@@ -78,9 +78,6 @@ typedef enum {
  *
  * Configures MCPWM Unit 0 / Timer 0 for standard RC servo timing of 50 Hz, 20
  * ms period.
- *
- * @note
- * stabilization delay of 500 ms applied to allow ESC arming.
  */
 void esc_init(void);
 

--- a/lib/drivers/esc/esc.h
+++ b/lib/drivers/esc/esc.h
@@ -2,6 +2,7 @@
 #define __ESC_H__
 
 #include <stdio.h>
+#include "motor/motor.h"
 #include "pwm/pwm.h"
 
 
@@ -9,67 +10,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-
-/**
- * @brief Logical motor identifiers.
- *
- * Defines the ordered mapping of drive motors in the system.
- *
- * - `MOTOR_L`: left motor.
- *
- * - `MOTOR_R`: right motor.
- */
-typedef enum {
-    MOTOR_L,
-    MOTOR_R,
-    NUMBER_OF_MOTORS
-} motor_t;
-
-/**
- * @brief Resolve MCPWM operator corresponding to a motor.
- *
- * Maps a `motor_t` to its associated MCPWM operator:
- *
- *  - `MOTOR_L`:    `MCPWM_OPR_A`
- *
- *  - `MOTOR_R`:    `MCPWM_OPR_B`
- *
- * @param motor Motor identifier (`motor_t`).
- *
- * @return MCPWM operator (`mcpwm_operator_t`).
- */
-#define MOTOR_OPERATOR(motor)   ((motor) == MOTOR_L ? MCPWM_OPR_A : MCPWM_OPR_B)
-
-/**
- * @brief Resolve GPIO pin corresponding to a motor.
- *
- * Maps a `motor_t` to its configured pin:
- *
- *  - `MOTOR_L`:    `PIN_ESC_L`
- *
- *  - `MOTOR_R`:    `PIN_ESC_R`
- *
- * @param motor Motor identifier (`motor_t`).
- *
- * @return GPIO number used for PWM output.
- */
-#define MOTOR_PIN(motor)        ((motor) == MOTOR_L ? PIN_ESC_L   : PIN_ESC_R  )
-
-/**
- * @brief Resolve MCPWM signal corresponding to a motor.
- *
- * Maps a `motor_t` to the corresponding MCPWM output signal:
- *
- *  - `MOTOR_L`:    `MCPWM0A`
- *  - `MOTOR_R`:    `MCPWM0B`
- *
- * @param motor Motor identifier (`motor_t`).
- *
- * @return MCPWM I/O signal identifier.
- */
-#define MOTOR_PWM(motor)        ((motor) == MOTOR_L ? MCPWM0A     : MCPWM0B    )
 
 
 
@@ -98,34 +38,8 @@ void esc_init(void);
 void esc_set_pwm(pwm_pulse_t pulse_us, motor_t motor);
 
 /**
- * @brief Stop both motors by commanding neutral PWM.
- *
- * Sets left and right ESC outputs to `PWM_NEUTRAL_US`, ensuring zero throttle
- * condition.
+ * 
  */
-void esc_set_pwm_neutral(motor_t motor);
-
-/**
- * @brief Apply differential drive mixing and update both motors.
- *
- * Implements skid-steering (tank drive) mixing:
- *
- * - `left  = throttle + steering - PWM_NEUTRAL_US`
- *
- * - `right = throttle - steering + PWM_NEUTRAL_US`
- *
- * @param pulses_us Input array:
- *
- *        - pulses_us[0]: Throttle in microseconds
- *
- *        - pulses_us[1]: Steering in microseconds
- */
-void esc_set_pwms(pwm_pulse_norm_t pulses_us[NUMBER_OF_MOTORS]);
-
-// TODO add docs
-void esc_set_pwms_neutral();
-
-
 void esc_validate(void);
 
 

--- a/lib/drivers/led/led.cpp
+++ b/lib/drivers/led/led.cpp
@@ -94,7 +94,5 @@ void led_validate() {
     for (size_t i = 0; i < COLORS_COUNT; i++) {
         led_set_color_all(COLORS[i][0], COLORS[i][1], COLORS[i][2]);
         FastLED.show();
-
-        delay(250);
     }
 }

--- a/lib/drivers/led/led.cpp
+++ b/lib/drivers/led/led.cpp
@@ -77,6 +77,16 @@ void led_set_color_all(uint8_t r, uint8_t g, uint8_t b) {
     );
 }
 
+void led_toggle(led_t led) {
+    brightness_t brightness = (brightness_t) FastLED.getBrightness();
+
+    led_set_brightness(
+        brightness >= BRIGHTNESS_MEDIUM ? BRIGHTNESS_OFF : BRIGHTNESS_MAX
+    );
+    delay(TOGGLE_DURATION_MS);
+    led_set_brightness(brightness);
+}
+
 
 void led_validate() {
     led_set_brightness(BRIGHTNESS_LOW);

--- a/lib/drivers/led/led.cpp
+++ b/lib/drivers/led/led.cpp
@@ -52,7 +52,7 @@ void led_set_brightness(brightness_t brightness) {
     FastLED.setBrightness(brightness);
     FastLED.show();
 
-    DEBUG_MSG(DEBUG_LEVEL_TRACE, "setting LEDs brigthness to %d", brightness);
+    DEBUG_MSG(DEBUG_LEVEL_TRACE, "setting LEDs brightness to %d", brightness);
 }
 
 

--- a/lib/drivers/led/led.h
+++ b/lib/drivers/led/led.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 
+#define TOGGLE_DURATION_MS 50
 
 /**
  * @brief Discrete LED brightness levels.
@@ -77,6 +78,9 @@ void led_set_color_all(uint8_t r, uint8_t g, uint8_t b);
  * @brief Set color of a single LED and update strip.
  */
 void led_set_color(led_t led, uint8_t r, uint8_t g, uint8_t b);
+
+
+void led_toggle(led_t led);
 
 
 void led_validate(void);

--- a/lib/drivers/led/led.h
+++ b/lib/drivers/led/led.h
@@ -10,7 +10,7 @@ extern "C" {
 #endif
 
 
-#define TOGGLE_DURATION_MS 50
+#define TOGGLE_DURATION_MS 100
 
 /**
  * @brief Discrete LED brightness levels.

--- a/lib/drivers/motion/motion.cpp
+++ b/lib/drivers/motion/motion.cpp
@@ -6,7 +6,7 @@
 
 
 
-void motion_rotate(angle_t angle) {
+void motion_rotation(angle_t angle) {
     if (angle == -45) {
         esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_L);
         esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_R);

--- a/lib/drivers/motion/motion.cpp
+++ b/lib/drivers/motion/motion.cpp
@@ -4,52 +4,54 @@
 #include "motor/motor.h"
 #include "pwm/pwm.h"
 
+int8_t offset = 50;
 
 
 void motion_rotation(angle_t angle) {
-    if (angle == -45) {
-        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_L);
-        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_R);
-
-        delay(40);
-    } else if (angle == +45) {
-        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_L);
+    if (angle == +45) {
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US - offset, MOTOR_L);
         esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_R);
 
-        delay(60);
+        delay(24);
+    } else if (angle == -45) {
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US + offset, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_R);
+
+        delay(30);
     } else if (angle == -90) {
-        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US + offset, MOTOR_L);
         esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_R);
 
-        delay(60);
+        delay(36);
     } else if (angle == +90) {
-        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US - offset, MOTOR_L);
         esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_R);
 
-        delay(100);
-    } else if (angle == -180) {
-        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_L);
-        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_R);
-
-        delay(125);
+        delay(36);
     } else if (angle == +180) {
-        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US - offset, MOTOR_L);
         esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_R);
 
-        delay(150);
+        delay(72);
     }
+
+    motors_set_pwm_neutral();
+    delay(50);
 }
 
 void motion_translation(distance_t distance) {
     if (distance == -50) {
-        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US + 120, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US+75, MOTOR_L);
         esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_R);
 
-        delay(500);
+        delay(135);
     } else if (distance == +50) {
         esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_L);
-        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US + 75, MOTOR_R);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US+25, MOTOR_R);
 
-        delay(200);
+        delay(115);
     }
+
+    motors_set_pwm_neutral();
+    delay(50);
 }

--- a/lib/drivers/motion/motion.cpp
+++ b/lib/drivers/motion/motion.cpp
@@ -1,0 +1,55 @@
+#include <Arduino.h>
+#include "esc/esc.h"
+#include "motion.h"
+#include "motor/motor.h"
+#include "pwm/pwm.h"
+
+
+
+void motion_rotate(angle_t angle) {
+    if (angle == -45) {
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_R);
+
+        delay(40);
+    } else if (angle == +45) {
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_R);
+
+        delay(60);
+    } else if (angle == -90) {
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_R);
+
+        delay(60);
+    } else if (angle == +90) {
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_R);
+
+        delay(100);
+    } else if (angle == -180) {
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US, MOTOR_R);
+
+        delay(125);
+    } else if (angle == +180) {
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_R);
+
+        delay(150);
+    }
+}
+
+void motion_translation(distance_t distance) {
+    if (distance == -50) {
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US + 120, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_R);
+
+        delay(500);
+    } else if (distance == +50) {
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MAXIMUM_US, MOTOR_L);
+        esc_set_pwm((pwm_pulse_norm_t) PWM_MINIMUM_US + 75, MOTOR_R);
+
+        delay(200);
+    }
+}

--- a/lib/drivers/motion/motion.h
+++ b/lib/drivers/motion/motion.h
@@ -9,7 +9,7 @@ extern "C"
 #endif
 
 /**
- * @brief Move rotation angle in degrees.
+ * @brief Angle of rotation in degrees.
  *
  * With:
  *
@@ -20,7 +20,7 @@ extern "C"
 typedef int16_t angle_t;
 
 /**
- * @brief Move distance angle in degrees.
+ * @brief Distance of translation in centimeters.
  *
  * With:
  *
@@ -31,14 +31,14 @@ typedef int16_t angle_t;
 typedef int16_t distance_t;
 
 /**
- * @brief Move motors so robot performs a rotation.
+ * @brief Perform in place rotation by an angle.
  *
  * @param angle rotation angle in degree.
  */
-void motion_rotate(angle_t angle);
+void motion_rotation(angle_t angle);
 
 /**
- * @brief Move motors so robot performs a translation.
+ * @brief Perform rectilinum translation by a distance.
  *
  * @param distance translation distance in centimeters.
  */

--- a/lib/drivers/motion/motion.h
+++ b/lib/drivers/motion/motion.h
@@ -1,0 +1,51 @@
+#ifndef __MOTION_H__
+#define __MOTION_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief Move rotation angle in degrees.
+ *
+ * With:
+ *
+ * - positive: clockwise sense
+ *
+ * - negative: counterclockwise sense
+ */
+typedef int16_t angle_t;
+
+/**
+ * @brief Move distance angle in degrees.
+ *
+ * With:
+ *
+ * - positive: forwards direction
+ *
+ * - negative: backwards direction
+ */
+typedef int16_t distance_t;
+
+/**
+ * @brief Move motors so robot performs a rotation.
+ *
+ * @param angle rotation angle in degree.
+ */
+void motion_rotate(angle_t angle);
+
+/**
+ * @brief Move motors so robot performs a translation.
+ *
+ * @param distance translation distance in centimeters.
+ */
+void motion_translation(distance_t distance);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MOTION_H__ */

--- a/lib/drivers/motor/motor.cpp
+++ b/lib/drivers/motor/motor.cpp
@@ -1,0 +1,26 @@
+#include "debug.h"
+#include "esc/esc.h"
+#include "motor.h"
+#include "pwm/pwm.h"
+
+
+
+void motor_set_pwm_neutral(motor_t motor) {
+    esc_set_pwm((pwm_pulse_t) PWM_NEUTRAL_US, motor);
+}
+
+void motors_set_pwm(pwm_pulse_norm_t pulses_us[NUMBER_OF_MOTORS]) {
+    pwm_pulse_norm_t steering_us = pulses_us[0];
+    DEBUG_MSG(DEBUG_LEVEL_TRACE, "measured steering: %d us", steering_us);
+
+    pwm_pulse_norm_t throttle_us = pulses_us[1];
+    DEBUG_MSG(DEBUG_LEVEL_TRACE, "measured throttle: %d us", throttle_us);
+
+    esc_set_pwm((pwm_pulse_t) throttle_us + steering_us - PWM_NEUTRAL_US, MOTOR_L);
+    esc_set_pwm((pwm_pulse_t) throttle_us - steering_us + PWM_NEUTRAL_US, MOTOR_R);
+};
+
+void motors_set_pwm_neutral() {
+    motor_set_pwm_neutral(MOTOR_L);
+    motor_set_pwm_neutral(MOTOR_R);
+};

--- a/lib/drivers/motor/motor.cpp
+++ b/lib/drivers/motor/motor.cpp
@@ -16,8 +16,8 @@ void motors_set_pwm(pwm_pulse_norm_t pulses_us[NUMBER_OF_MOTORS]) {
     pwm_pulse_norm_t throttle_us = pulses_us[1];
     DEBUG_MSG(DEBUG_LEVEL_TRACE, "measured throttle: %d us", throttle_us);
 
-    esc_set_pwm((pwm_pulse_t) throttle_us + steering_us - PWM_NEUTRAL_US, MOTOR_L);
-    esc_set_pwm((pwm_pulse_t) throttle_us - steering_us + PWM_NEUTRAL_US, MOTOR_R);
+    esc_set_pwm((pwm_pulse_t) steering_us + throttle_us - PWM_NEUTRAL_US, MOTOR_L);
+    esc_set_pwm((pwm_pulse_t) steering_us - throttle_us + PWM_NEUTRAL_US, MOTOR_R);
 };
 
 void motors_set_pwm_neutral() {

--- a/lib/drivers/motor/motor.h
+++ b/lib/drivers/motor/motor.h
@@ -1,0 +1,112 @@
+#ifndef __MOTOR_H__
+#define __MOTOR_H__
+
+#include <stdint.h>
+#include "pwm/pwm.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+
+/**
+ * @brief Logical motor identifiers.
+ *
+ * Defines the ordered mapping of drive motors in the system.
+ *
+ * - `MOTOR_L`: left motor.
+ *
+ * - `MOTOR_R`: right motor.
+ */
+typedef enum {
+    MOTOR_L,
+    MOTOR_R,
+    NUMBER_OF_MOTORS
+} motor_t;
+
+/**
+ * @brief Resolve MCPWM operator corresponding to a motor.
+ *
+ * Maps a `motor_t` to its associated MCPWM operator:
+ *
+ *  - `MOTOR_L`:    `MCPWM_OPR_A`
+ *
+ *  - `MOTOR_R`:    `MCPWM_OPR_B`
+ *
+ * @param motor Motor identifier (`motor_t`).
+ *
+ * @return MCPWM operator (`mcpwm_operator_t`).
+ */
+#define MOTOR_OPERATOR(motor)   ((motor) == MOTOR_L ? MCPWM_OPR_A : MCPWM_OPR_B)
+
+/**
+ * @brief Resolve GPIO pin corresponding to a motor.
+ *
+ * Maps a `motor_t` to its configured pin:
+ *
+ *  - `MOTOR_L`:    `PIN_ESC_L`
+ *
+ *  - `MOTOR_R`:    `PIN_ESC_R`
+ *
+ * @param motor Motor identifier (`motor_t`).
+ *
+ * @return GPIO number used for PWM output.
+ */
+#define MOTOR_PIN(motor)        ((motor) == MOTOR_L ? PIN_ESC_L   : PIN_ESC_R  )
+
+/**
+ * @brief Resolve MCPWM signal corresponding to a motor.
+ *
+ * Maps a `motor_t` to the corresponding MCPWM output signal:
+ *
+ *  - `MOTOR_L`:    `MCPWM0A`
+ *  - `MOTOR_R`:    `MCPWM0B`
+ *
+ * @param motor Motor identifier (`motor_t`).
+ *
+ * @return MCPWM I/O signal identifier.
+ */
+#define MOTOR_PWM(motor)        ((motor) == MOTOR_L ? MCPWM0A     : MCPWM0B    )
+
+
+
+/**
+ * @brief Stop motor by commanding neutral PWM.
+ *
+ * Set ESC input to `PWM_NEUTRAL_US`, ensuring zero PWM condition.
+ */
+void motor_set_pwm_neutral(motor_t motor);
+
+/**
+ * @brief Apply differential drive mixing and update both motors.
+ *
+ * Implements skid-steering (tank drive) mixing:
+ *
+ * - `l = throttle + steering - PWM_NEUTRAL_US`
+ *
+ * - `r = throttle - steering + PWM_NEUTRAL_US`
+ *
+ * @param pulses_us array of radio pulses:
+ *
+ *        - pulses_us[0]: steering in microseconds
+ *
+ *        - pulses_us[1]: throttle in microseconds
+ */
+void motors_set_pwm(pwm_pulse_norm_t pulses_us[NUMBER_OF_MOTORS]);
+
+/**
+ * @brief Stop both motors by commanding neutral PWM.
+ *
+ * Set both ESCs inputs to `PWM_NEUTRAL_US`, ensuring zero PWM condition.
+ */
+void motors_set_pwm_neutral();
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MOTOR_H__ */

--- a/lib/drivers/pwm/pwm.cpp
+++ b/lib/drivers/pwm/pwm.cpp
@@ -3,11 +3,11 @@
 
 
 pwm_pulse_norm_t IRAM_ATTR pwm_pulse_us_normalize(pwm_pulse_t pulse_us) {
-    if (pulse_us > (pwm_pulse_t) PWM_MAXIMUM_US) {
+    if (pulse_us > (pwm_pulse_t) PWM_MAXIMUM_US - PWM_DEADBAND_US) {
         return (pwm_pulse_norm_t) PWM_MAXIMUM_US;
     }
 
-    if (pulse_us < (pwm_pulse_t) PWM_MINIMUM_US) {
+    if (pulse_us < (pwm_pulse_t) PWM_MINIMUM_US + PWM_DEADBAND_US) {
         return (pwm_pulse_norm_t) PWM_MINIMUM_US;
     }
 

--- a/lib/drivers/pwm/pwm.cpp
+++ b/lib/drivers/pwm/pwm.cpp
@@ -21,3 +21,17 @@ pwm_pulse_norm_t IRAM_ATTR pwm_pulse_us_normalize(pwm_pulse_t pulse_us) {
 
     return (pwm_pulse_norm_t) pulse_us;
 };
+
+pwm_pulse_norm_t pwm_pulse_percentage(percentage_t percentage) {
+    if (percentage > +100) {
+        percentage = +100;
+    }
+
+    if (percentage < -100) {
+        percentage = -100;
+    }
+
+    return pwm_pulse_us_normalize(
+        (pwm_pulse_t) PWM_NEUTRAL_US + 5 * percentage
+    );
+}

--- a/lib/drivers/pwm/pwm.h
+++ b/lib/drivers/pwm/pwm.h
@@ -76,6 +76,15 @@ typedef uint32_t pwm_pulse_norm_t;
  */
 #define PWM_MINIMUM_US      1000U
 
+/**
+ * @brief 25% pulse threshold in microseconds.
+ */
+#define PWM_THRESHOUD_25    (PWM_NEUTRAL_US + PWM_MINIMUM_US) / 2
+
+/**
+ * @brief 75% pulse threshold in microseconds.
+ */
+#define PWM_THRESHOUD_75    (PWM_NEUTRAL_US + PWM_MAXIMUM_US) / 2
 
 
 /**

--- a/lib/drivers/pwm/pwm.h
+++ b/lib/drivers/pwm/pwm.h
@@ -21,6 +21,10 @@ extern "C" {
 #endif
 
 
+/**
+ * TODO
+ */
+typedef int8_t percentage_t;
 
 /**
  * @typedef pwm_pulse_t
@@ -36,7 +40,6 @@ typedef int16_t pwm_pulse_t;
 typedef uint32_t pwm_pulse_norm_t;
 
 #ifndef IRAM_ATTR
-
 /**
  * @brief IRAM_ATTR is a macro used in ESP32 programming to place functions, particularly interrupt service routines (ISRs), in Instruction RAM (IRAM).
  */
@@ -105,6 +108,11 @@ typedef uint32_t pwm_pulse_norm_t;
  */
 pwm_pulse_norm_t IRAM_ATTR pwm_pulse_us_normalize(pwm_pulse_t pulse_us);
 
+/**
+ * TODO
+ * @brief returns PWM pulse in us based on PWM percentage. forward is positive, reverse is negative.
+ */
+pwm_pulse_norm_t pwm_pulse_percentage(percentage_t percentage);
 
 
 #ifdef __cplusplus

--- a/lib/drivers/pwm/pwm.h
+++ b/lib/drivers/pwm/pwm.h
@@ -48,6 +48,9 @@ typedef uint32_t pwm_pulse_norm_t;
  *
  * Pulses within `PWM_DEADBAND_US` distance of `PWM_NEUTRAL_US` are forced to
  * `PWM_NEUTRAL_US`.
+ * 
+ * @note
+ * - button debounce requires at least 50.
  */
 #define PWM_DEADBAND_US       50U
 

--- a/lib/drivers/radio/radio.cpp
+++ b/lib/drivers/radio/radio.cpp
@@ -129,53 +129,28 @@ pwm_pulse_norm_t radio_read_channel(channel_t channel) {
 
 
 radio_status_t radio_status() {
-    pwm_pulse_norm_t pulses_us[NUMBER_OF_CHANNELS];
-    radio_read_channels(pulses_us);
+    uint disconnected_channels = 0;
 
-
-    bool all_neutral = true;
+    noInterrupts();
+    uint32_t now = micros();
     for (uint8_t i = 0; i < NUMBER_OF_CHANNELS; i++) {
-        if (pulses_us[i] != (pwm_pulse_norm_t) PWM_NEUTRAL_US) {
-            all_neutral = false;
-
-            DEBUG_MSG(
-                DEBUG_LEVEL_ERROR,
-                "channel %d receiving %d us when %d us expected",
-                i, pulse_width[i], PWM_NEUTRAL_US
-            );
-
-            break;
+        if (now - last_update[i] > RADIO_TIMEOUT_US) {
+            disconnected_channels++;
         }
     }
-    if (all_neutral) {
-        status = RADIO_DISCONNECTED;
+    interrupts();
 
-        DEBUG_MSG(
-            DEBUG_LEVEL_INFO, "current Radio Controller status is %d", status
-        );
-        return status;
+    if (disconnected_channels >= NUMBER_OF_CHANNELS - 1) {
+        status = RADIO_DISCONNECTED;
+    } else {
+        status = RADIO_CONNECTED;
     }
 
-
-    // if (pulses_us[CHANNEL_ENABLE] > (pwm_pulse_norm_t) (PWM_NEUTRAL_US + PWM_DEADBAND_US)) {
-    //     status = RADIO_CONNECTED_ENABLE;
-    // } else {
-    //     status = RADIO_CONNECTED_DISABLE;
-    // }
+    DEBUG_MSG(
+        DEBUG_LEVEL_INFO, "current Radio Controller status is %d", status
+    );
 
     return status;
-};
-
-
-radio_status_t radio_status_pin() {
-    pwm_pulse_t steering_us = radio_read_pin(PIN_RADIO_CH1);
-    pwm_pulse_t throttle_us = radio_read_pin(PIN_RADIO_CH2);
-
-    if (steering_us == 0 || throttle_us == 0) {
-        return RADIO_DISCONNECTED;
-    }
-
-    return RADIO_CONNECTED_ENABLE;
 };
 
 

--- a/lib/drivers/radio/radio.cpp
+++ b/lib/drivers/radio/radio.cpp
@@ -130,11 +130,6 @@ pwm_pulse_norm_t radio_read_channel(channel_t channel) {
 };
 
 
-pwm_pulse_t radio_read_pin(uint8_t pin) {
-    return pulseIn(pin, HIGH, 25000);
-};
-
-
 radio_status_t radio_status() {
     pwm_pulse_norm_t pulses_us[NUMBER_OF_CHANNELS];
     radio_read_channels(pulses_us);

--- a/lib/drivers/radio/radio.cpp
+++ b/lib/drivers/radio/radio.cpp
@@ -107,8 +107,7 @@ void radio_read_channels(pwm_pulse_norm_t pulses_us[NUMBER_OF_CHANNELS]) {
 
     for (uint8_t i = 0; i < NUMBER_OF_CHANNELS; i++) {
         DEBUG_MSG(
-            DEBUG_LEVEL_TRACE,
-            "channel %d receiving %d us", i, pulse_width[i]
+            DEBUG_LEVEL_TRACE, "channel %d receiving %d us", i, pulses_us[i]
         );
     }
 };
@@ -122,8 +121,7 @@ pwm_pulse_norm_t radio_read_channel(channel_t channel) {
     interrupts();
 
     DEBUG_MSG(
-        DEBUG_LEVEL_TRACE,
-        "channel %d receiving %d us", channel, pulse_width[channel]
+        DEBUG_LEVEL_TRACE, "channel %d receiving %d us", channel, pulse_us
     );
 
     return pulse_us;

--- a/lib/drivers/radio/radio.cpp
+++ b/lib/drivers/radio/radio.cpp
@@ -77,22 +77,23 @@ static void IRAM_ATTR radio_isr(void* arg) {
 void radio_init() {
     DEBUG_MSG(DEBUG_LEVEL_INFO, "initialization of Radio Controller started");
 
+    uint32_t now = micros();
     for (uint8_t i = 0; i < NUMBER_OF_CHANNELS; i++) {
-        pinMode(channels_pins[i], INPUT);
+        pinMode(channels[i], INPUT);
 
         attachInterruptArg(
-            digitalPinToInterrupt(channels_pins[i]),
+            digitalPinToInterrupt(channels[i]),
             radio_isr,
             (void*)(uintptr_t) i,
             CHANGE
         );
 
-        rise_time[i]    = 0;
-        pulse_width[i]  = (pwm_pulse_norm_t) PWM_NEUTRAL_US;
-        last_update[i]  = 0;
+        rise_time[i]    = now;
+        pulse_width[i]  = (pwm_pulse_t) PWM_NEUTRAL_US;
+        last_update[i]  = now;
     }
 
-    status = RADIO_CONNECTED_DISABLE;
+    status = RADIO_DISCONNECTED;
 
     DEBUG_MSG(DEBUG_LEVEL_INFO, "initialization of Radio Controller finish");
 };

--- a/lib/drivers/radio/radio.cpp
+++ b/lib/drivers/radio/radio.cpp
@@ -14,13 +14,13 @@ static volatile pwm_pulse_norm_t    pulse_width[NUMBER_OF_CHANNELS];
 static volatile uint32_t            last_update[NUMBER_OF_CHANNELS];
 static radio_status_t               status = RADIO_DISCONNECTED;
 
-static const uint8_t channels_pins[NUMBER_OF_CHANNELS] = {
+static const uint8_t channels[NUMBER_OF_CHANNELS] = {
     PIN_RADIO_CH1,
     PIN_RADIO_CH2,
-    // PIN_RADIO_CH3,
-    // PIN_RADIO_CH4,
-    // PIN_RADIO_CH5,
-    // PIN_RADIO_CH6
+    PIN_RADIO_CH3,
+    PIN_RADIO_CH4,
+    PIN_RADIO_CH5,
+    PIN_RADIO_CH6
 };
 
 
@@ -58,17 +58,20 @@ static const uint8_t channels_pins[NUMBER_OF_CHANNELS] = {
  *   and accessed atomically or within critical sections.
  */
 static void IRAM_ATTR radio_isr(void* arg) {
-    uint8_t channel = (uint8_t)(uintptr_t) arg; // portable cast
+    uint8_t i       = (uint8_t)(uintptr_t) arg; // portable cast
+
     uint32_t now    = micros();
-    uint32_t level  = (REG_READ(GPIO_IN_REG) >> channels_pins[channel]) & 0x1;
+    uint32_t level  = (REG_READ(GPIO_IN1_REG) >> (channels[i] - 32)) & 0x1;
 
     if (level) {    // rising edge
-        rise_time[channel] = now;
+        rise_time[i] = now;
     } else {        // falling edge
-        pwm_pulse_t pulse_us = (pwm_pulse_t) (now - rise_time[channel]);
+        if (rise_time[i] != 0) {
+            pwm_pulse_t pulse_us = (pwm_pulse_t) (now - rise_time[i]);
 
-        pulse_width[channel] = pwm_pulse_us_normalize(pulse_us);
-        last_update[channel] = millis();
+            pulse_width[i] = pwm_pulse_us_normalize(pulse_us);
+            last_update[i] = now;
+        }
     }
 }
 

--- a/lib/drivers/radio/radio.cpp
+++ b/lib/drivers/radio/radio.cpp
@@ -133,7 +133,7 @@ pwm_pulse_norm_t radio_read_channel(channel_t channel) {
 
 
 radio_status_t radio_status() {
-    uint disconnected_channels = 0;
+    uint8_t disconnected_channels = 0;
 
     noInterrupts();
     uint32_t now = micros();
@@ -144,15 +144,18 @@ radio_status_t radio_status() {
     }
     interrupts();
 
+    static radio_status_t new_status;
     if (disconnected_channels >= NUMBER_OF_CHANNELS - 1) {
-        status = RADIO_DISCONNECTED;
+        new_status = RADIO_DISCONNECTED;
     } else {
-        status = RADIO_CONNECTED;
+        new_status = RADIO_CONNECTED;
     }
 
-    DEBUG_MSG(
-        DEBUG_LEVEL_INFO, "current Radio Controller status is %d", status
-    );
+    if (new_status != status) {
+        DEBUG_MSG(DEBUG_LEVEL_WARNING, "radio status: %d", new_status);
+
+        status = new_status;
+    }
 
     return status;
 };

--- a/lib/drivers/radio/radio.h
+++ b/lib/drivers/radio/radio.h
@@ -20,6 +20,9 @@ extern "C" {
 
 
 
+#define RADIO_TIMEOUT_US    20000
+
+
 /**
  * @brief Logical indices for RC receiver channels.
  */

--- a/lib/drivers/radio/radio.h
+++ b/lib/drivers/radio/radio.h
@@ -38,16 +38,13 @@ typedef enum {
  *
  * Represents the current operational state of the RC link:
  *
- * - `RADIO_CONNECTED_ENABLE`:  Valid signal present and enable switch active.
+ * - `RADIO_CONNECTED`:     Valid signal present and enable switch active.
  *
- * - `RADIO_CONNECTED_DISABLE`: Valid signal present but enable switch inactive.
- *
- * - `RADIO_DISCONNECTED`:      No valid signal detected.
+ * - `RADIO_DISCONNECTED`:  No valid signal detected.
  */
 typedef enum {
-    RADIO_CONNECTED_ENABLE,     /**< Valid signal present and enable switch active. */
-    RADIO_CONNECTED_DISABLE,    /**< Valid signal present but enable switch inactive. */
-    RADIO_DISCONNECTED          /**< No valid signal detected. */
+    RADIO_CONNECTED,    /**< Valid signal present and enable switch active. */
+    RADIO_DISCONNECTED  /**< No valid signal detected. */
 } radio_status_t;
 
 

--- a/lib/drivers/radio/radio.h
+++ b/lib/drivers/radio/radio.h
@@ -76,19 +76,13 @@ void radio_read_channels(pwm_pulse_norm_t pulses_us[NUMBER_OF_CHANNELS]);
  */
 pwm_pulse_norm_t radio_read_channel(channel_t channel);
 
-
-pwm_pulse_t radio_read_pin(uint8_t pin);
-
-
-void radio_validate(void);
-
 /**
  * @brief Returns the current radio connection state.
  */
 radio_status_t radio_status(void);
 
 
-radio_status_t radio_status_pin();
+void radio_validate(void);
 
 
 

--- a/lib/drivers/radio/radio.h
+++ b/lib/drivers/radio/radio.h
@@ -26,10 +26,10 @@ extern "C" {
 typedef enum {
     CHANNEL_STEERING = 0,
     CHANNEL_THROTTLE,
-    // CHANNEL_3,
-    // CHANNEL_ENABLE,
-    // CHANNEL_5,
-    // CHANNEL_6,
+    CHANNEL_BUTTON,
+    CHANNEL_4,
+    CHANNEL_5,
+    CHANNEL_6,
     NUMBER_OF_CHANNELS
 } channel_t;
 

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -188,6 +188,7 @@ void fsm_init(void) {
     DEBUG_MSG(DEBUG_LEVEL_INFO, "initialization Finite State Machine started");
 
     led_init();
+    led_set_brightness(BRIGHTNESS_MEDIUM);
     radio_init();
     esc_init();
 
@@ -526,7 +527,6 @@ static void safe_entry(void) {
     DEBUG_MSG(DEBUG_LEVEL_INFO, "entring of STATE_SAFE");
 
     led_set_color(LED_STATE, COLOR_YELLOW);
-    led_set_brightness(BRIGHTNESS_MEDIUM);
 
     esc_set_pwms_neutral();
 }

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -407,10 +407,10 @@ static void opening_run(void) {
         return;
     }
 
-    if (opening_step < OPENING_ITERATIONS) {
-        pwm_pulse_norm_t pulses_us[NUMBER_OF_CHANNELS];
-        radio_read_channels(pulses_us);
+    pwm_pulse_norm_t pulses_us[NUMBER_OF_CHANNELS];
+    radio_read_channels(pulses_us);
 
+    if (opening_step < OPENING_ITERATIONS) {
         // ensure inital button value is not PWM_NEUTRAL_US
         if (
             button_us == PWM_NEUTRAL_US &&
@@ -432,14 +432,18 @@ static void opening_run(void) {
             }
             opening_strategy = 10 * opening_strategy + increase;
             DEBUG_MSG(
-                DEBUG_LEVEL_WARNING, "opening_strategy: %d", opening_strategy
+                DEBUG_LEVEL_WARNING, "current opening: %d", opening_strategy
             );
 
             led_toggle(LED_STATE);
             opening_step++;
         }
-    } else {
-        DEBUG_MSG(DEBUG_LEVEL_INFO, "opening_strategy: %d", opening_strategy);
+    } else if (
+        opening_step == OPENING_ITERATIONS &&
+        button_us != pulses_us[CHANNEL_BUTTON]
+    ) {
+        button_us = pulses_us[CHANNEL_BUTTON];
+        DEBUG_MSG(DEBUG_LEVEL_WARNING, "running opening: %d", opening_strategy);
 
         switch (opening_strategy) {
             case OPENING_STATIC:

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -78,55 +78,6 @@ static void survive_run(void);
 // FSM State Table Definition
 // -----------------------------------------------------------------------------
 
-/**
- * @brief Mermaid FSM Diagram
- *
-stateDiagram-v2
-    classDef autonomous fill:#900
-    classDef common     fill:#909
-    classDef radio      fill:#009
-    
-    class STATE_ATTACK, STATE_COUNTDOWN, STATE_SEARCH autonomous
-    class STATE_MANUAL radio
-    class STATE_SAFE, STATE_SURVIVE common
- 
-    
-    direction TB
-    state IF_SAFE <<choice>>
-
-
-    %% INITIALIZATION
-    [*] --> STATE_SAFE:                 fsm_init()
-    STATE_SAFE --> [*]
-
-
-    %% COMMON
-
-    STATE_SAFE --> IF_SAFE:             if radio_status() == RADIO_CONNECTED_ENABLE
-    IF_SAFE --> STATE_COUNTDOWN:        if CONTROL_MODE == AUTONOMOUS
-    IF_SAFE --> STATE_MANUAL:           if CONTROL_MODE == RADIO
-
-    %%STATE_SURVIVE --> STATE_MANUAL:     if edge_status() != EDGE_DETECTED
-    STATE_SURVIVE --> STATE_SEARCH:     if edge_status() != EDGE_DETECTED
-
-
-    %% AUTONOMOUS
-    STATE_ATTACK --> STATE_SURVIVE:     if edge_status() == EDGE_DETECTED
-
-    STATE_COUNTDOWN --> STATE_SAFE:     if radio_status() != RADIO_CONNECTED_ENABLE
-    STATE_COUNTDOWN --> STATE_SEARCH:   if millis() - state_timer_ms >= 5000
-
-    STATE_SEARCH --> STATE_ATTACK:      if edge_status() != EDGE_DETECTED && if oponent_status() == OPONENT_DETECDED
-    STATE_SEARCH --> STATE_SAFE:        if radio_status() != RADIO_CONNECTED_ENABLE
-    STATE_SEARCH --> STATE_SURVIVE:     if edge_status() == EDGE_DETECTED
-
-
-    %% RADIO CONTROLLED
-    STATE_MANUAL --> STATE_SAFE:        if radio_status() != RADIO_CONNECTED_ENABLE
-    %%STATE_MANUAL --> STATE_SURVIVE:     if edge_status() == EDGE_DETECTED
- */
-
-
 static const fsm_state_table_t state_table[NUMBER_OF_STATES] = {
     [STATE_ATTACK] = {
         .name     = "ATTACK",

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -395,29 +395,25 @@ static void manual_entry(void) {
  * @brief Manual state run handler.
  *
  * In `RADIO_CONNECTED_ENABLE` state, reads steering and throttle radio channels
- * and forwards them directly to the ESC outputs.
+ * and forwards them mixed in a tank combination to the ESC outputs.
  *
  * If the radio becomes disabled or disconnected, transitions immediately to
  * `STATE_SAFE` for safety.
  */
 static void manual_run(void) {
     if (radio_status() == RADIO_DISCONNECTED) {
+        DEBUG_MSG(DEBUG_LEVEL_WARNING, "lost radio signal.");
 
-        fsm_transition(STATE_SAFE); 
+        fsm_transition(STATE_SAFE);
         return;
     }
 
-    pwm_pulse_norm_t steering_us = radio_read_pin(PIN_RADIO_CH1);
-    pwm_pulse_norm_t throttle_us = radio_read_pin(PIN_RADIO_CH2);
+    pwm_pulse_norm_t pulses_us[NUMBER_OF_MOTORS] = {
+        radio_read_channel(CHANNEL_STEERING),
+        radio_read_channel(CHANNEL_THROTTLE)
+    };
 
-    DEBUG_MSG(DEBUG_LEVEL_TRACE, "measured steering: %d us", steering_us);
-    DEBUG_MSG(DEBUG_LEVEL_TRACE, "measured throttle: %d us", throttle_us);
-
-    long left_us  = throttle_us + steering_us - PWM_NEUTRAL_US;
-    long right_us = throttle_us - steering_us + PWM_NEUTRAL_US;
-
-    esc_set_pwm((pwm_pulse_t) left_us,  MOTOR_L);
-    esc_set_pwm((pwm_pulse_t) right_us, MOTOR_R);
+    esc_set_pwms(pulses_us);
 }
 
 /**

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -446,14 +446,14 @@ static void opening_run(void) {
                 break;
 
             case OPENING_DRAW:
-                motion_rotate(+180);
+                motion_rotation(+180);
 
                 break;
 
             case OPENING_NE:
-                motion_rotate(+45);
+                motion_rotation(+45);
                 motion_translation(+50);
-                motion_rotate(-45);
+                motion_rotation(-45);
 
                 break;
 
@@ -463,26 +463,26 @@ static void opening_run(void) {
                 break;
 
             case OPENING_NW:
-                motion_rotate(-45);
+                motion_rotation(-45);
                 motion_translation(+50);
-                motion_rotate(+45);
+                motion_rotation(+45);
 
                 break;
 
             case OPENING_SE:
-                motion_rotate(-45);
+                motion_rotation(-45);
                 motion_translation(-50);
 
                 break;
 
             case OPENING_SS:
-                motion_rotate(-45);
+                motion_rotation(-45);
                 motion_translation(-50);
 
                 break;
 
             case OPENING_SW:
-                motion_rotate(+45);
+                motion_rotation(+45);
                 motion_translation(-50);
 
                 break;
@@ -510,8 +510,8 @@ static void safe_entry(void) {
 /**
  * @brief Safe state run handler.
  *
- * Monitors radio status and transitions to `STATE_COUNTDOWN` when a valid
- * enable signal is detected.
+ * Monitors radio status and transitions to `STATE_COUNTDOWN`, `STATE_MANUAL` or
+ * `STATE_OPENING` when a valid enable signal is detected.
  */
 static void safe_run(void) {
     // Safety lock

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -355,7 +355,7 @@ static void manual_entry(void) {
  */
 static void manual_run(void) {
     if (radio_status() == RADIO_DISCONNECTED) {
-        DEBUG_MSG(DEBUG_LEVEL_WARNING, "lost radio signal.");
+        DEBUG_MSG(DEBUG_LEVEL_WARNING, "lost radio signal");
 
         fsm_transition(STATE_SAFE);
         return;
@@ -401,7 +401,7 @@ static void opening_entry(void) {
  */
 static void opening_run(void) {
     if (radio_status() == RADIO_DISCONNECTED) {
-        DEBUG_MSG(DEBUG_LEVEL_WARNING, "lost radio signal.");
+        DEBUG_MSG(DEBUG_LEVEL_WARNING, "lost radio signal");
 
         fsm_transition(STATE_SAFE);
         return;
@@ -439,7 +439,7 @@ static void opening_run(void) {
             opening_step++;
         }
     } else {
-        DEBUG_MSG(DEBUG_LEVEL_INFO, "opening_strategy is %d", opening_strategy);
+        DEBUG_MSG(DEBUG_LEVEL_INFO, "opening_strategy: %d", opening_strategy);
 
         switch (opening_strategy) {
             case OPENING_STATIC:
@@ -516,13 +516,11 @@ static void safe_entry(void) {
 static void safe_run(void) {
     // Safety lock
     if (radio_status() == RADIO_CONNECTED) {
-        if (CONTROL_MODE == AUTONOMOUS) {
-            DEBUG_MSG(DEBUG_LEVEL_INFO, "current control mode is AUTONOMOUS");
+        DEBUG_MSG(DEBUG_LEVEL_INFO, "control mode: %d", CONTROL_MODE);
 
+        if (CONTROL_MODE == AUTONOMOUS) {
             fsm_transition(STATE_COUNTDOWN);
         } else {
-            DEBUG_MSG(DEBUG_LEVEL_INFO, "current control mode is RADIO");
-
             if (opening_step == OPENING_ITERATIONS) {
                 fsm_transition(STATE_MANUAL);
             } else {

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <stdio.h>
 #include "config.h"
 #include "esc/esc.h"
 #include "fsm.h"
@@ -33,6 +34,13 @@ static uint32_t state_timer_ms      = 0;
 
 
 
+static uint32_t opening_step        = 0;
+static uint32_t opening_strategy;
+
+static pwm_pulse_norm_t button_us   = 0;
+
+
+
 // -----------------------------------------------------------------------------
 // FSM State Functions
 // -----------------------------------------------------------------------------
@@ -49,6 +57,9 @@ static void countdown_run(void);
 static void manual_entry(void);
 static void manual_run(void);
 static void manual_exit(void);
+
+static void opening_entry(void);
+static void opening_run(void);
 
 static void search_entry(void);
 static void search_run(void);
@@ -141,6 +152,12 @@ static const fsm_state_table_t state_table[NUMBER_OF_STATES] = {
         .on_entry = manual_entry,
         .on_run   = manual_run,
         .on_exit  = manual_exit
+    },
+    [STATE_OPENING] = {
+        .name     = "OPENING",
+        .on_entry = opening_entry,
+        .on_run   = opening_run,
+        .on_exit  = NULL,
     },
     [STATE_SAFE] = {
         .name     = "SAFE",
@@ -428,9 +445,88 @@ static void manual_run(void) {
  * preventing unintended motion during transition.
  */
 static void manual_exit(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "exiting of STATE_MANUAL");
+// --- OPENING ---
 
-    stop_motors();
+/**
+ * @brief Opening state entry handler.
+ *
+ * Sets visual indication upon entering `STATE_OPENING`.
+ */
+static void opening_entry(void) {
+    led_set_color(LED_STATE, COLOR_PURPLE);
+
+    button_us = radio_read_channel(CHANNEL_THROTTLE);//TODO modify to CHANNEL_BUTTON
+}
+
+/**
+ * @brief Opening state run handler.
+ *
+ * Reads throttle value in 3 sequencial steps to determine the opening move
+ * requested among the defined below:
+ */
+static void opening_run(void) {
+    if (radio_status() == RADIO_DISCONNECTED) {
+        DEBUG_MSG(DEBUG_LEVEL_WARNING, "lost radio signal.");
+
+        fsm_transition(STATE_SAFE);
+        return;
+    }
+
+    if (opening_step < OPENING_ITERATIONS) {
+        pwm_pulse_norm_t pulses_us[NUMBER_OF_CHANNELS];
+        radio_read_channels(pulses_us);
+
+        if (button_us != pulses_us[CHANNEL_THROTTLE]) {// TODO modify to CHANNEL_BUTTON
+            button_us = pulses_us[CHANNEL_THROTTLE];// TODO modify to CHANNEL_BUTTON
+
+            if (
+                pulses_us[CHANNEL_STEERING] <   // TODO modify to CHANNEL_THROTTLE
+                (PWM_NEUTRAL_US + PWM_MINIMUM_US) / 2
+            ) {
+                opening_strategy += 1 * pow10((double) opening_step);
+            } else if (
+                pulses_us[CHANNEL_STEERING] >   // TODO modify to CHANNEL_THROTTLE
+                (PWM_NEUTRAL_US + PWM_MAXIMUM_US) / 2
+            ) {
+                opening_strategy += 2 * pow10((double) opening_step);
+            } else {
+                opening_strategy += 0;
+            }
+
+            led_toggle(LED_STATE);
+            opening_step++;
+        }
+    } else {
+        DEBUG_MSG(DEBUG_LEVEL_INFO, "opening_strategy is %d", opening_strategy);
+
+        switch (opening_strategy) {
+            case OPENING_STATIC:
+                break;
+
+            case OPENING_DRAW:
+                break;
+
+            case OPENING_NE:
+                break;
+
+            case OPENING_NN:
+                break;
+
+            case OPENING_NW:
+                break;
+
+            case OPENING_SE:
+                break;
+
+            case OPENING_SS:
+                break;
+
+            case OPENING_SW:
+                break;
+        }
+
+        fsm_transition(STATE_MANUAL);
+    }
 }
 
 
@@ -470,7 +566,11 @@ static void safe_run(void) {
         } else {
             DEBUG_MSG(DEBUG_LEVEL_INFO, "current control mode is RADIO");
 
-            fsm_transition(STATE_MANUAL);
+            if (opening_step == OPENING_ITERATIONS) {
+                fsm_transition(STATE_MANUAL);
+            } else {
+                fsm_transition(STATE_OPENING);
+            }
         }
     }
 

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -296,7 +296,7 @@ static void attack_run(void) {
     DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_ATTACK");
 
     // Safety abort
-    if (radio_status() != RADIO_CONNECTED_ENABLE) {
+    if (radio_status() != RADIO_CONNECTED) {
         DEBUG_MSG(DEBUG_LEVEL_WARNING, "unable to connect with radio");
         fsm_transition(STATE_SAFE);
 
@@ -361,7 +361,7 @@ static void countdown_run(void) {
     DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_COUNTDOWN");
 
     // Safety abort
-    if (radio_status() != RADIO_CONNECTED_ENABLE) {
+    if (radio_status() != RADIO_CONNECTED) {
         DEBUG_MSG(DEBUG_LEVEL_WARNING, "unable to connect with radio");
         fsm_transition(STATE_SAFE);
 
@@ -399,10 +399,7 @@ static void manual_entry(void) {
  * `STATE_SAFE` for safety.
  */
 static void manual_run(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_MANUAL");
-
-    if (radio_status_pin() == RADIO_DISCONNECTED) {
-        DEBUG_MSG(DEBUG_LEVEL_WARNING, "Radio signal lost (pulseIn timeout). Stopping motors.");
+    if (radio_status() == RADIO_DISCONNECTED) {
 
         fsm_transition(STATE_SAFE); 
         return;
@@ -541,11 +538,7 @@ static void safe_entry(void) {
  * enable signal is detected.
  */
 static void safe_run(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_SAFE");
-
-    if (radio_status_pin() == RADIO_CONNECTED_ENABLE) {
-        DEBUG_MSG(DEBUG_LEVEL_INFO, "radio status is RADIO_CONNECTED_ENABLE");
-
+    if (radio_status() == RADIO_CONNECTED) {
         if (CONTROL_MODE == AUTONOMOUS) {
             DEBUG_MSG(DEBUG_LEVEL_INFO, "current control mode is AUTONOMOUS");
 
@@ -590,7 +583,7 @@ static void search_run(void) {
     DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_SEARCH");
 
     // Safety abort
-    if (radio_status() != RADIO_CONNECTED_ENABLE) {
+    if (radio_status() != RADIO_CONNECTED) {
         DEBUG_MSG(DEBUG_LEVEL_WARNING, "unable to connect with radio");
         fsm_transition(STATE_SAFE);
 
@@ -631,7 +624,7 @@ static void survive_run(void) {
     DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_SURVIVE");
 
     // Safety abort
-    if (radio_status() != RADIO_CONNECTED_ENABLE) {
+    if (radio_status() != RADIO_CONNECTED) {
         DEBUG_MSG(DEBUG_LEVEL_WARNING, "unable to connect with radio");
         fsm_transition(STATE_SAFE);
 

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -472,7 +472,7 @@ static void opening_run(void) {
  * entering the safe state.
  */
 static void safe_entry(void) {
-    led_set_color(LED_STATE, COLOR_YELLOW);
+    led_set_color(LED_STATE, COLOR_RED);
 
     esc_set_pwms_neutral();
 }

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -222,14 +222,26 @@ void fsm_transition(fsm_state_t new_state) {
 
     // 1. execute Exit Action of current state
     if (state_table[current_state].on_exit != NULL) {
+        DEBUG_MSG(
+            DEBUG_LEVEL_INFO, "exiting of %s", state_table[current_state].name
+        );
+
         state_table[current_state].on_exit();
     }
 
     // 2. update state
+        DEBUG_MSG(
+            DEBUG_LEVEL_INFO, "entrying of %s", state_table[current_state].name
+        );
+
     current_state = new_state;
 
     // 3. execute Entry Action of new state
     if (state_table[current_state].on_entry != NULL) {
+        DEBUG_MSG(
+            DEBUG_LEVEL_INFO, "entrying of %s", state_table[current_state].name
+        );
+
         state_table[current_state].on_entry();
     }
 }
@@ -237,6 +249,10 @@ void fsm_transition(fsm_state_t new_state) {
 
 void fsm_step(void) {
     if (state_table[current_state].on_run != NULL) {
+        DEBUG_MSG(
+            DEBUG_LEVEL_INFO, "running of %s", state_table[current_state].name
+        );
+
         return state_table[current_state].on_run();
     }
 
@@ -253,8 +269,7 @@ const char* get_current_state_name(void) {
     }
 
     DEBUG_MSG(
-        DEBUG_LEVEL_ERROR,
-        "no name defined for current state %d", current_state
+        DEBUG_LEVEL_ERROR, "no name defined for current state %d", current_state
     );
 
     return "UNKNOWN";
@@ -280,8 +295,6 @@ fsm_state_t get_current_state(void) {
  * Sets visual indication upon entering `STATE_ATTACK`.
  */
 static void attack_entry(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "entrying of STATE_ATTACK");
-
     led_set_color(LED_STATE, COLOR_SCARLET);
 
     // TODO: Set ESCs to full forward speed
@@ -294,8 +307,6 @@ static void attack_entry(void) {
  * authorization is lost.
  */
 static void attack_run(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_ATTACK");
-
     // Safety abort
     if (radio_status() != RADIO_CONNECTED) {
         DEBUG_MSG(DEBUG_LEVEL_WARNING, "unable to connect with radio");
@@ -318,8 +329,6 @@ static void attack_run(void) {
  * Sets visual indication upon entering `STATE_BOOT`.
  */
 static void boot_entry(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "entrying of STATE_BOOT");
-
     led_set_color(LED_STATE, COLOR_WHITE);
 }
 
@@ -329,8 +338,6 @@ static void boot_entry(void) {
  * First .
  */
 static void boot_run(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_BOOT");
-
     fsm_transition(STATE_SAFE);
 }
 
@@ -344,8 +351,6 @@ static void boot_run(void) {
  * for time-based transition.
  */
 static void countdown_entry(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "entrying of STATE_COUNTDOWN");
-
     led_set_color(LED_STATE, COLOR_ORANGE_LIGHT);
     state_timer_ms = millis();
 
@@ -359,8 +364,6 @@ static void countdown_entry(void) {
  * radio enable signal is lost, immediately transitions back to `STATE_SAFE`.
  */
 static void countdown_run(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_COUNTDOWN");
-
     // Safety abort
     if (radio_status() != RADIO_CONNECTED) {
         DEBUG_MSG(DEBUG_LEVEL_WARNING, "unable to connect with radio");
@@ -385,8 +388,6 @@ static void countdown_run(void) {
  * Sets visual indication upon entering `STATE_MANUAL`.
  */
 static void manual_entry(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "entrying of STATE_MANUAL");
-
     led_set_color(LED_STATE, COLOR_GREEN);
 }
 
@@ -524,8 +525,6 @@ static void opening_run(void) {
  * entering the safe state.
  */
 static void safe_entry(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "entring of STATE_SAFE");
-
     led_set_color(LED_STATE, COLOR_YELLOW);
 
     esc_set_pwms_neutral();
@@ -553,8 +552,6 @@ static void safe_run(void) {
             }
         }
     }
-
-    DEBUG_MSG(DEBUG_LEVEL_WARNING, "radio status is RADIO_DISCONNECTED");
 }
 
 
@@ -566,8 +563,6 @@ static void safe_run(void) {
  * Sets visual indication upon entering `STATE_SEARCH`.
  */
 static void search_entry(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "entring of STATE_SEARCH");
-
     led_set_color(LED_STATE, COLOR_BLUE);
 
     // TODO: Set ESCs to perform a slow spin or search pattern
@@ -580,8 +575,6 @@ static void search_entry(void) {
  * enable signal is lost.
  */
 static void search_run(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_SEARCH");
-
     // Safety abort
     if (radio_status() != RADIO_CONNECTED) {
         DEBUG_MSG(DEBUG_LEVEL_WARNING, "unable to connect with radio");
@@ -604,8 +597,6 @@ static void search_run(void) {
  * entry timestamp for time-based logic.
  */
 static void survive_entry(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "entring of STATE_SURVIVE");
-
     led_set_color(LED_STATE, COLOR_PURPLE);
 
     // TODO: Set ESCs to hard reverse
@@ -621,8 +612,6 @@ static void survive_entry(void) {
  * - After 500 ms from state entry, transitions to `STATE_SEARCH`.
  */
 static void survive_run(void) {
-    DEBUG_MSG(DEBUG_LEVEL_INFO, "running of STATE_SURVIVE");
-
     // Safety abort
     if (radio_status() != RADIO_CONNECTED) {
         DEBUG_MSG(DEBUG_LEVEL_WARNING, "unable to connect with radio");

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -70,7 +70,6 @@ static void safe_run(void);
 static void survive_entry(void);
 static void survive_run(void);
 
-static void stop_motors(void);
 
 
 
@@ -271,22 +270,6 @@ fsm_state_t get_current_state(void) {
 // State Behaviors
 // -----------------------------------------------------------------------------
 
-/**
- * @brief Stop both motors by commanding neutral PWM.
- *
- * Sets left and right ESC outputs to `PWM_NEUTRAL_US`, ensuring zero throttle
- * condition.
- */
-static void stop_motors(void) {
-    DEBUG_MSG(
-        DEBUG_LEVEL_INFO,
-        "stopping motors"
-    );
-
-    esc_set_pwm((pwm_pulse_t) PWM_NEUTRAL_US, MOTOR_L);
-    esc_set_pwm((pwm_pulse_t) PWM_NEUTRAL_US, MOTOR_R);
-}
-
 
 // --- ATTACK ---
 
@@ -445,6 +428,10 @@ static void manual_run(void) {
  * preventing unintended motion during transition.
  */
 static void manual_exit(void) {
+    esc_set_pwms_neutral();
+}
+
+
 // --- OPENING ---
 
 /**
@@ -544,7 +531,7 @@ static void safe_entry(void) {
     led_set_color(LED_STATE, COLOR_YELLOW);
     led_set_brightness(BRIGHTNESS_MEDIUM);
 
-    stop_motors();
+    esc_set_pwms_neutral();
 }
 
 /**

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -5,6 +5,7 @@
 #include "fsm.h"
 #include "led/colors.h"
 #include "led/led.h"
+#include "motor/motor.h"
 #include "radio/radio.h"
 #include "pinout.h"
 #include "pwm/pwm.h"
@@ -364,7 +365,7 @@ static void manual_run(void) {
         radio_read_channel(CHANNEL_THROTTLE)
     };
 
-    esc_set_pwms(pulses_us);
+    motors_set_pwm(pulses_us);
 }
 
 /**
@@ -374,7 +375,7 @@ static void manual_run(void) {
  * preventing unintended motion during transition.
  */
 static void manual_exit(void) {
-    esc_set_pwms_neutral();
+    motors_set_pwm_neutral();
 }
 
 
@@ -474,7 +475,7 @@ static void opening_run(void) {
 static void safe_entry(void) {
     led_set_color(LED_STATE, COLOR_RED);
 
-    esc_set_pwms_neutral();
+    motors_set_pwm_neutral();
 }
 
 /**

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -450,44 +450,162 @@ static void opening_run(void) {
                 break;
 
             case OPENING_DRAW:
-                motion_rotation(+180);
+                // rotation     +180
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(80);
+                motors_set_pwm_neutral();
+                delay(1);
 
                 break;
 
             case OPENING_NE:
-                motion_rotation(+45);
-                motion_translation(+50);
-                motion_rotation(-45);
+                // rotation     +045
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(25);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                // translation  +50
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_R);
+                delay(140);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                // rotation     -090
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_R);
+                delay(65);
+                motors_set_pwm_neutral();
+                delay(1);
 
                 break;
 
             case OPENING_NN:
-                motion_translation(+50);
+                // translation  +50
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_R);
+                delay(140);
+                motors_set_pwm_neutral();
+                delay(1);
 
                 break;
 
             case OPENING_NW:
-                motion_rotation(-45);
-                motion_translation(+50);
-                motion_rotation(+45);
+                // rotation     -045
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_R);
+                delay(25);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                // translation  +50
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_R);
+                delay(140);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                // rotation     +090
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(65);
+                motors_set_pwm_neutral();
+                delay(1);
 
                 break;
 
             case OPENING_SE:
-                motion_rotation(-45);
-                motion_translation(-50);
+                // rotation     -045
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_R);
+                delay(30);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                // translation  -50
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(120);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                // rotation     +090
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(60);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                break;
+
+            case OPENING_SEN:
+                // rotation     -045
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_R);
+                delay(30);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                // translation  -50
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(120);
+                motors_set_pwm_neutral();
+                delay(1);
 
                 break;
 
             case OPENING_SS:
-                motion_rotation(-45);
-                motion_translation(-50);
+                // translation  -50
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(120);
+                motors_set_pwm_neutral();
+                delay(1);
 
                 break;
 
             case OPENING_SW:
-                motion_rotation(+45);
-                motion_translation(-50);
+                // rotation     +045
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(30);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                // translation  -50
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(120);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                // rotation     -090
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_R);
+                delay(60);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                break;
+
+            case OPENING_SWN:
+                // rotation     +045
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(20);
+                motors_set_pwm_neutral();
+                delay(1);
+
+                // translation  -50
+                esc_set_pwm(pwm_pulse_percentage(-90), MOTOR_L);
+                esc_set_pwm(pwm_pulse_percentage(+90), MOTOR_R);
+                delay(120);
+                motors_set_pwm_neutral();
+                delay(1);
 
                 break;
         }

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -5,6 +5,7 @@
 #include "fsm.h"
 #include "led/colors.h"
 #include "led/led.h"
+#include "motion/motion.h"
 #include "motor/motor.h"
 #include "radio/radio.h"
 #include "pinout.h"
@@ -438,24 +439,45 @@ static void opening_run(void) {
                 break;
 
             case OPENING_DRAW:
+                motion_rotate(+180);
+
                 break;
 
             case OPENING_NE:
+                motion_rotate(+45);
+                motion_translation(+50);
+                motion_rotate(-45);
+
                 break;
 
             case OPENING_NN:
+                motion_translation(+50);
+
                 break;
 
             case OPENING_NW:
+                motion_rotate(-45);
+                motion_translation(+50);
+                motion_rotate(+45);
+
                 break;
 
             case OPENING_SE:
+                motion_rotate(-45);
+                motion_translation(-50);
+
                 break;
 
             case OPENING_SS:
+                motion_rotate(-45);
+                motion_translation(-50);
+
                 break;
 
             case OPENING_SW:
+                motion_rotate(+45);
+                motion_translation(-50);
+
                 break;
         }
 

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -390,7 +390,7 @@ static void manual_exit(void) {
 static void opening_entry(void) {
     led_set_color(LED_STATE, COLOR_PURPLE);
 
-    button_us = radio_read_channel(CHANNEL_THROTTLE);//TODO modify to CHANNEL_BUTTON
+    button_us = radio_read_channel(CHANNEL_BUTTON);
 }
 
 /**
@@ -411,22 +411,29 @@ static void opening_run(void) {
         pwm_pulse_norm_t pulses_us[NUMBER_OF_CHANNELS];
         radio_read_channels(pulses_us);
 
-        if (button_us != pulses_us[CHANNEL_THROTTLE]) {// TODO modify to CHANNEL_BUTTON
-            button_us = pulses_us[CHANNEL_THROTTLE];// TODO modify to CHANNEL_BUTTON
+        // ensure inital button value is not PWM_NEUTRAL_US
+        if (
+            button_us == PWM_NEUTRAL_US &&
+            pulses_us[CHANNEL_BUTTON] != PWM_NEUTRAL_US
+        ) {
+            button_us = pulses_us[CHANNEL_BUTTON];
+        }
 
-            if (
-                pulses_us[CHANNEL_STEERING] <   // TODO modify to CHANNEL_THROTTLE
-                (PWM_NEUTRAL_US + PWM_MINIMUM_US) / 2
-            ) {
-                opening_strategy += 1 * pow10((double) opening_step);
-            } else if (
-                pulses_us[CHANNEL_STEERING] >   // TODO modify to CHANNEL_THROTTLE
-                (PWM_NEUTRAL_US + PWM_MAXIMUM_US) / 2
-            ) {
-                opening_strategy += 2 * pow10((double) opening_step);
+        if (button_us != pulses_us[CHANNEL_BUTTON]) {
+            button_us = pulses_us[CHANNEL_BUTTON];
+
+            uint32_t increase;
+            if (pulses_us[CHANNEL_THROTTLE] > PWM_THRESHOUD_75) {
+                increase = 2;
+            } else if (pulses_us[CHANNEL_THROTTLE] < PWM_THRESHOUD_25) {
+                increase = 1;
             } else {
-                opening_strategy += 0;
+                increase = 0;
             }
+            opening_strategy = 10 * opening_strategy + increase;
+            DEBUG_MSG(
+                DEBUG_LEVEL_WARNING, "opening_strategy: %d", opening_strategy
+            );
 
             led_toggle(LED_STATE);
             opening_step++;

--- a/lib/fsm/fsm.cpp
+++ b/lib/fsm/fsm.cpp
@@ -533,6 +533,7 @@ static void safe_entry(void) {
  * enable signal is detected.
  */
 static void safe_run(void) {
+    // Safety lock
     if (radio_status() == RADIO_CONNECTED) {
         if (CONTROL_MODE == AUTONOMOUS) {
             DEBUG_MSG(DEBUG_LEVEL_INFO, "current control mode is AUTONOMOUS");

--- a/lib/fsm/fsm.h
+++ b/lib/fsm/fsm.h
@@ -62,12 +62,13 @@ typedef void (*fsm_action_t)(void);
  *
  * - on_exit:  Executed once immediately before transitioning OUT of
  *             this state.
- *             Intedended for cleanup or safe shutdown actions.
+ *             Intended for cleanup or safe shutdown actions.
  *
  * Any callback may be `NULL` if not required.
  *
  * @note
  * - callbacks must be deterministic and non-blocking.
+ *
  * - transitions are managed by the FSM engine.
  */
 typedef struct {

--- a/lib/fsm/fsm.h
+++ b/lib/fsm/fsm.h
@@ -35,13 +35,15 @@ typedef enum {
 
 typedef enum {
     OPENING_STATIC  =   0,
-    OPENING_DRAW    = 111,
-    OPENING_NE      = 122,
+    OPENING_DRAW    =   1,
+    OPENING_NE      = 221,
     OPENING_NN      =  20,
-    OPENING_NW      = 221,
-    OPENING_SE      =  11,
+    OPENING_NW      = 122,
+    OPENING_SEN     = 210,
+    OPENING_SE      = 212,
     OPENING_SS      =  10,
-    OPENING_SW      =  12,
+    OPENING_SW      = 111,
+    OPENING_SWN     = 110,
 } opening_t;
 
 typedef void (*fsm_action_t)(void);

--- a/lib/fsm/fsm.h
+++ b/lib/fsm/fsm.h
@@ -34,14 +34,14 @@ typedef enum {
 } fsm_state_t;
 
 typedef enum {
-    OPENING_STATIC  = 000,
+    OPENING_STATIC  =   0,
     OPENING_DRAW    = 111,
     OPENING_NE      = 122,
-    OPENING_NN      = 020,
+    OPENING_NN      =  20,
     OPENING_NW      = 221,
-    OPENING_SE      = 011,
-    OPENING_SS      = 010,
-    OPENING_SW      = 012,
+    OPENING_SE      =  11,
+    OPENING_SS      =  10,
+    OPENING_SW      =  12,
 } opening_t;
 
 typedef void (*fsm_action_t)(void);

--- a/lib/fsm/fsm.h
+++ b/lib/fsm/fsm.h
@@ -26,11 +26,23 @@ typedef enum {
     STATE_BOOT,
     STATE_COUNTDOWN,
     STATE_MANUAL,
+    STATE_OPENING,
     STATE_SAFE,
     STATE_SEARCH,
     STATE_SURVIVE,
     NUMBER_OF_STATES
 } fsm_state_t;
+
+typedef enum {
+    OPENING_STATIC  = 000,
+    OPENING_DRAW    = 111,
+    OPENING_NE      = 122,
+    OPENING_NN      = 020,
+    OPENING_NW      = 221,
+    OPENING_SE      = 011,
+    OPENING_SS      = 010,
+    OPENING_SW      = 012,
+} opening_t;
 
 typedef void (*fsm_action_t)(void);
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,9 +22,9 @@ build_flags =
     -I $PROJECT_INCLUDE_DIR
 
 
-[env:esp32-s3-devkitm-1]
+[env:esp32-s3-devkitc-1]
 platform        = espressif32
-board           = esp32-s3-devkitm-1
+board           = esp32-s3-devkitc-1
 framework       = arduino
 monitor_raw     = yes                   ; required for colored debug messages
 monitor_speed   = 115200

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,6 @@
 
 void setup() {
     debug_init(115200);
-    delay(2500);
 
     DEBUG_MSG(DEBUG_LEVEL_INFO, "initialization system start");
 
@@ -19,6 +18,4 @@ void setup() {
 
 void loop() {
     fsm_step();
-
-    // delay(100);
 }


### PR DESCRIPTION
## Description

Addition of opening move in the RC control mode. Radio Controller functions were also modified to improve responsiveness with the use of interruptions instead of `pulseIn()` blocking functions.

## Related Issue

Close #35 

## Checklist
- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add unique feature``)
